### PR TITLE
Fix Uncaught Exception on Connection Loss in Main Process

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -163,6 +163,12 @@ app.on('ready', () => {
     }
   }
 
+  process.on('uncaughtException', (error) => {
+      tray.setContextMenu(createTrayMenu('Error', 'Error', 'Error'));
+      tray.setImage(icon.fail);
+      log.error(error);
+  })
+
   app.dock.hide();
   app.on('window-all-closed', () => {});
   tray.on('right-click', requestContributionData);


### PR DESCRIPTION
Right now, the electron app throws a really obnoxious exception whenever an existing connection is broken. This creates a new dialog window and is generally a pain in the ass for me as a user, as addressed in #7 

![blerg](https://user-images.githubusercontent.com/6846386/45531194-619c8500-b7a3-11e8-9a35-3b958150a841.gif)

This creates a handler for uncaught exceptions in the main node process according to: https://nodejs.org/api/process.html#process_event_uncaughtexception

Now the exception flow looks more like this:

![yay](https://user-images.githubusercontent.com/6846386/45531204-6f520a80-b7a3-11e8-82e0-ace3537e3570.gif)

We can decide to handle the issue in a different way but this seems appropriate to me.

